### PR TITLE
feat: set up Go backend skeleton

### DIFF
--- a/.claude/skills/golang/SKILL.md
+++ b/.claude/skills/golang/SKILL.md
@@ -134,7 +134,7 @@ description: |
 
 ## Recommended Libraries
 
-- Web: Fiber
+- Web: Chi (go-chi/chi)
 - DB: Bun, SQLBoiler (when managing migrations externally)
 - Logging: slog
 - CLI: cobra

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,36 @@
+name: Backend Tests
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+      - reopened
+      - unlocked
+    paths:
+      - "src/backend/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/backend/**"
+  workflow_dispatch:
+
+jobs:
+  backend-tests:
+    name: Run Backend tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@master
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.24
+
+      - name: Set up Just CLI
+        uses: extractions/setup-just@v3
+
+      - name: Run Backend tests
+        run: just test backend

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 docs/work
 .claude/settings.local.json
+src/backend/tmp

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,5 @@
 module.exports = {
   "**/*.{json,yml,yaml,md}": () => "just lint config",
   justfile: () => "just lint justfile",
+  "**/*.go": () => "just lint go",
 };

--- a/justfile
+++ b/justfile
@@ -14,12 +14,45 @@ lint target="all":
       all)
         just lint justfile
         just lint config
+        just lint go
         ;;
       justfile)
         just --fmt --unstable
         ;;
       config)
         npx prettier --write "**/*.{json,yml,yaml,md}"
+        ;;
+      go)
+        gofmt -w src/backend
+        ;;
+      *)
+        echo "Unknown target: {{ target }}"
+        exit 1
+        ;;
+    esac
+
+run target:
+    #!/usr/bin/env bash
+    set -euox pipefail
+    case "{{ target }}" in
+      backend)
+        cd src/backend && air
+        ;;
+      *)
+        echo "Unknown target: {{ target }}"
+        exit 1
+        ;;
+    esac
+
+test target="all":
+    #!/usr/bin/env bash
+    set -euox pipefail
+    case "{{ target }}" in
+      all)
+        just test backend
+        ;;
+      backend)
+        cd src/backend && go test -v ./...
         ;;
       *)
         echo "Unknown target: {{ target }}"

--- a/src/backend/.air.toml
+++ b/src/backend/.air.toml
@@ -1,0 +1,20 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  cmd = "go build -o ./tmp/main ./cmd/server"
+  bin = "./tmp/main"
+  delay = 1000
+  exclude_dir = ["tmp"]
+  exclude_regex = ["_test\\.go$"]
+  include_ext = ["go"]
+  kill_delay = "2s"
+
+[log]
+  time = false
+
+[color]
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"

--- a/src/backend/cmd/server/main.go
+++ b/src/backend/cmd/server/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/specvital/web/src/backend/common/middleware"
+	"github.com/specvital/web/src/backend/health"
+)
+
+const (
+	defaultPort     = "3000"
+	shutdownTimeout = 10 * time.Second
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	if err := run(); err != nil {
+		slog.Error("application failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	origins, err := middleware.GetAllowedOrigins()
+	if err != nil {
+		return fmt.Errorf("failed to get allowed origins: %w", err)
+	}
+
+	router := newRouter(origins)
+	return startServer(router)
+}
+
+func newRouter(origins []string) *chi.Mux {
+	r := chi.NewRouter()
+
+	r.Use(chimiddleware.RequestID)
+	r.Use(chimiddleware.RealIP)
+	r.Use(middleware.Logger())
+	r.Use(chimiddleware.Recoverer)
+	r.Use(middleware.CORS(origins))
+
+	health.RegisterRoutes(r)
+
+	return r
+}
+
+func startServer(handler http.Handler) error {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	addr := fmt.Sprintf(":%s", port)
+	server := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		slog.Info("starting server", "addr", addr)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("server failed: %w", err)
+	case <-quit:
+	}
+
+	slog.Info("shutting down server")
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		return fmt.Errorf("server forced to shutdown: %w", err)
+	}
+
+	slog.Info("server exited")
+	return nil
+}

--- a/src/backend/common/middleware/cors.go
+++ b/src/backend/common/middleware/cors.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/go-chi/cors"
+)
+
+const (
+	corsMaxAge     = 3600
+	defaultOrigin  = "http://localhost:3000"
+	envCORSOrigins = "CORS_ORIGINS"
+	envEnv         = "ENV"
+	envProduction  = "production"
+	wildcardOrigin = "*"
+)
+
+var (
+	ErrCORSOriginsNotSet = errors.New("CORS_ORIGINS not set in production")
+	ErrWildcardOrigin    = errors.New("wildcard origin not allowed with credentials")
+)
+
+func CORS(origins []string) func(http.Handler) http.Handler {
+	return cors.Handler(cors.Options{
+		AllowCredentials: true,
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedOrigins:   origins,
+		ExposedHeaders:   []string{"Link"},
+		MaxAge:           corsMaxAge,
+	})
+}
+
+func GetAllowedOrigins() ([]string, error) {
+	origins := os.Getenv(envCORSOrigins)
+	if origins == "" {
+		if os.Getenv(envEnv) == envProduction {
+			return nil, ErrCORSOriginsNotSet
+		}
+		return []string{defaultOrigin}, nil
+	}
+
+	var result []string
+	for o := range strings.SplitSeq(origins, ",") {
+		origin := strings.TrimSpace(o)
+		if origin == wildcardOrigin {
+			return nil, ErrWildcardOrigin
+		}
+		if origin != "" {
+			result = append(result, origin)
+		}
+	}
+	return result, nil
+}

--- a/src/backend/common/middleware/cors_test.go
+++ b/src/backend/common/middleware/cors_test.go
@@ -1,0 +1,124 @@
+package middleware
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestGetAllowedOrigins(t *testing.T) {
+	tests := []struct {
+		name       string
+		envOrigins string
+		envEnv     string
+		want       []string
+		wantErr    error
+		setOrigins bool
+		setEnv     bool
+	}{
+		{
+			name:       "default origins when no env set",
+			setOrigins: false,
+			setEnv:     false,
+			want:       []string{"http://localhost:3000"},
+			wantErr:    nil,
+		},
+		{
+			name:       "custom multiple origins",
+			envOrigins: "https://example.com, https://api.example.com",
+			setOrigins: true,
+			setEnv:     false,
+			want:       []string{"https://example.com", "https://api.example.com"},
+			wantErr:    nil,
+		},
+		{
+			name:       "single origin",
+			envOrigins: "https://myapp.com",
+			setOrigins: true,
+			setEnv:     false,
+			want:       []string{"https://myapp.com"},
+			wantErr:    nil,
+		},
+		{
+			name:       "error on missing origins in production",
+			envOrigins: "",
+			envEnv:     "production",
+			setOrigins: false,
+			setEnv:     true,
+			want:       nil,
+			wantErr:    ErrCORSOriginsNotSet,
+		},
+		{
+			name:       "error on wildcard origin",
+			envOrigins: "https://example.com,*",
+			setOrigins: true,
+			setEnv:     false,
+			want:       nil,
+			wantErr:    ErrWildcardOrigin,
+		},
+		{
+			name:       "handles empty string between commas",
+			envOrigins: "https://example.com,,https://api.example.com",
+			setOrigins: true,
+			setEnv:     false,
+			want:       []string{"https://example.com", "https://api.example.com"},
+			wantErr:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv("CORS_ORIGINS")
+			os.Unsetenv("ENV")
+			t.Cleanup(func() {
+				os.Unsetenv("CORS_ORIGINS")
+				os.Unsetenv("ENV")
+			})
+
+			if tt.setOrigins {
+				os.Setenv("CORS_ORIGINS", tt.envOrigins)
+			}
+			if tt.setEnv {
+				os.Setenv("ENV", tt.envEnv)
+			}
+
+			got, err := GetAllowedOrigins()
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("expected error %v, got nil", tt.wantErr)
+					return
+				}
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("expected error %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(got) != len(tt.want) {
+				t.Errorf("expected %d origins, got %d", len(tt.want), len(got))
+				return
+			}
+
+			for i, want := range tt.want {
+				if got[i] != want {
+					t.Errorf("origin[%d]: expected %s, got %s", i, want, got[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCORS_ReturnsHandler(t *testing.T) {
+	origins := []string{"http://localhost:3000"}
+
+	handler := CORS(origins)
+	if handler == nil {
+		t.Error("expected non-nil handler")
+	}
+}

--- a/src/backend/common/middleware/logger.go
+++ b/src/backend/common/middleware/logger.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/httplog/v2"
+)
+
+const serviceName = "specvital-web"
+
+func Logger() func(http.Handler) http.Handler {
+	logger := httplog.NewLogger(serviceName, httplog.Options{
+		LogLevel:       slog.LevelInfo,
+		Concise:        true,
+		RequestHeaders: true,
+	})
+
+	return httplog.RequestLogger(logger)
+}

--- a/src/backend/go.mod
+++ b/src/backend/go.mod
@@ -1,0 +1,9 @@
+module github.com/specvital/web/src/backend
+
+go 1.24.0
+
+require (
+	github.com/go-chi/chi/v5 v5.2.0
+	github.com/go-chi/cors v1.2.1
+	github.com/go-chi/httplog/v2 v2.1.1
+)

--- a/src/backend/go.sum
+++ b/src/backend/go.sum
@@ -1,0 +1,6 @@
+github.com/go-chi/chi/v5 v5.2.0 h1:Aj1EtB0qR2Rdo2dG4O94RIU35w2lvQSj6BRA4+qwFL0=
+github.com/go-chi/chi/v5 v5.2.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
+github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
+github.com/go-chi/httplog/v2 v2.1.1 h1:ojojiu4PIaoeJ/qAO4GWUxJqvYUTobeo7zmuHQJAxRk=
+github.com/go-chi/httplog/v2 v2.1.1/go.mod h1:/XXdxicJsp4BA5fapgIC3VuTD+z0Z/VzukoB3VDc1YE=

--- a/src/backend/health/handler.go
+++ b/src/backend/health/handler.go
@@ -1,0 +1,27 @@
+package health
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const statusOK = "ok"
+
+type Response struct {
+	Status string `json:"status"`
+}
+
+func RegisterRoutes(r chi.Router) {
+	r.Get("/health", handleHealth)
+}
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(Response{Status: statusOK}); err != nil {
+		slog.Error("failed to encode health response", "error", err)
+	}
+}

--- a/src/backend/health/handler_test.go
+++ b/src/backend/health/handler_test.go
@@ -1,0 +1,49 @@
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandleHealth(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", contentType)
+	}
+
+	var response Response
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if response.Status != "ok" {
+		t.Errorf("expected status 'ok', got '%s'", response.Status)
+	}
+}
+
+func TestRegisterRoutes(t *testing.T) {
+	r := chi.NewRouter()
+	RegisterRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+}


### PR DESCRIPTION
Implement HTTP server with Chi router
- health check endpoint (`GET /health`)
- middleware: CORS, Logger, RequestID, Recoverer
- graceful shutdown support
- hot-reload dev environment with air

Tech stack: Chi, go-chi/cors, go-chi/httplog/v2

fix #5