### PR TITLE
feat: implement mock analyzer API endpoint

### DIFF
--- a/src/backend/analyzer/handler.go
+++ b/src/backend/analyzer/handler.go
@@ -1,0 +1,34 @@
+package analyzer
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/specvital/web/src/backend/common/dto"
+)
+
+func RegisterRoutes(r chi.Router) {
+	r.Route("/api/analyze", func(r chi.Router) {
+		r.Get("/{owner}/{repo}", handleAnalyze)
+	})
+}
+
+func handleAnalyze(w http.ResponseWriter, r *http.Request) {
+	owner := chi.URLParam(r, "owner")
+	repo := chi.URLParam(r, "repo")
+
+	if owner == "" || repo == "" {
+		dto.SendProblemDetail(w, r, http.StatusBadRequest, "Bad Request", "owner and repo are required")
+		return
+	}
+
+	result := GenerateMockResult(owner, repo)
+
+	w.Header().Set(dto.ContentTypeHeader, dto.JSONContentType)
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		slog.Error("failed to encode analysis result", "error", err)
+	}
+}

--- a/src/backend/analyzer/handler_test.go
+++ b/src/backend/analyzer/handler_test.go
@@ -1,0 +1,113 @@
+package analyzer
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/specvital/web/src/backend/common/dto"
+)
+
+func TestHandleAnalyze(t *testing.T) {
+	r := chi.NewRouter()
+	RegisterRoutes(r)
+
+	t.Run("returns mock analysis result", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/analyze/facebook/react", nil)
+		rec := httptest.NewRecorder()
+
+		r.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+
+		contentType := rec.Header().Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", contentType)
+		}
+
+		var result AnalysisResult
+		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+
+		if result.Owner != "facebook" {
+			t.Errorf("expected owner facebook, got %s", result.Owner)
+		}
+
+		if result.Repo != "react" {
+			t.Errorf("expected repo react, got %s", result.Repo)
+		}
+
+		if result.Summary.Total == 0 {
+			t.Error("expected non-zero total tests")
+		}
+
+		if len(result.Suites) == 0 {
+			t.Error("expected non-empty test suites")
+		}
+	})
+
+	t.Run("includes framework summary", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/analyze/vercel/next.js", nil)
+		rec := httptest.NewRecorder()
+
+		r.ServeHTTP(rec, req)
+
+		var result AnalysisResult
+		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+
+		if len(result.Summary.Frameworks) == 0 {
+			t.Error("expected non-empty framework summaries")
+		}
+
+		for _, fw := range result.Summary.Frameworks {
+			if fw.Total != fw.Active+fw.Skipped+fw.Todo {
+				t.Errorf("framework %s: total mismatch, expected %d, got %d",
+					fw.Framework, fw.Active+fw.Skipped+fw.Todo, fw.Total)
+			}
+		}
+	})
+
+	t.Run("returns 400 when owner is missing", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/analyze//repo", nil)
+		rec := httptest.NewRecorder()
+
+		r.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+		}
+
+		contentType := rec.Header().Get("Content-Type")
+		if contentType != "application/problem+json" {
+			t.Errorf("expected Content-Type application/problem+json, got %s", contentType)
+		}
+
+		var problem dto.ProblemDetail
+		if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+			t.Fatalf("failed to decode problem response: %v", err)
+		}
+
+		if problem.Status != http.StatusBadRequest {
+			t.Errorf("expected problem status %d, got %d", http.StatusBadRequest, problem.Status)
+		}
+	})
+
+	t.Run("returns 404 when repo path is incomplete", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/analyze/owner/", nil)
+		rec := httptest.NewRecorder()
+
+		r.ServeHTTP(rec, req)
+
+		// Chi router returns 404 when the route pattern doesn't match
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+		}
+	})
+}

--- a/src/backend/analyzer/mock.go
+++ b/src/backend/analyzer/mock.go
@@ -1,0 +1,109 @@
+package analyzer
+
+import "time"
+
+const mockCommitSHA = "abc1234def5678"
+
+func calculateSummary(suites []TestSuite) Summary {
+	frameworkStats := make(map[Framework]*FrameworkSummary)
+	var totalActive, totalSkipped, totalTodo int
+
+	for _, suite := range suites {
+		stats, exists := frameworkStats[suite.Framework]
+		if !exists {
+			stats = &FrameworkSummary{Framework: suite.Framework}
+			frameworkStats[suite.Framework] = stats
+		}
+
+		for _, test := range suite.Tests {
+			stats.Total++
+			switch test.Status {
+			case TestStatusActive:
+				stats.Active++
+				totalActive++
+			case TestStatusSkipped:
+				stats.Skipped++
+				totalSkipped++
+			case TestStatusTodo:
+				stats.Todo++
+				totalTodo++
+			}
+		}
+	}
+
+	frameworks := make([]FrameworkSummary, 0, len(frameworkStats))
+	for _, stats := range frameworkStats {
+		frameworks = append(frameworks, *stats)
+	}
+
+	return Summary{
+		Active:     totalActive,
+		Frameworks: frameworks,
+		Skipped:    totalSkipped,
+		Todo:       totalTodo,
+		Total:      totalActive + totalSkipped + totalTodo,
+	}
+}
+
+// GenerateMockResult creates mock analysis data for development and testing.
+func GenerateMockResult(owner, repo string) AnalysisResult {
+	suites := []TestSuite{
+		{
+			FilePath:  "src/components/Button.test.tsx",
+			Framework: FrameworkJest,
+			Tests: []TestCase{
+				{FilePath: "src/components/Button.test.tsx", Framework: FrameworkJest, Line: 5, Name: "renders correctly", Status: TestStatusActive},
+				{FilePath: "src/components/Button.test.tsx", Framework: FrameworkJest, Line: 15, Name: "handles click events", Status: TestStatusActive},
+				{FilePath: "src/components/Button.test.tsx", Framework: FrameworkJest, Line: 25, Name: "applies custom className", Status: TestStatusActive},
+				{FilePath: "src/components/Button.test.tsx", Framework: FrameworkJest, Line: 35, Name: "supports disabled state", Status: TestStatusSkipped},
+			},
+		},
+		{
+			FilePath:  "src/hooks/useAuth.test.ts",
+			Framework: FrameworkJest,
+			Tests: []TestCase{
+				{FilePath: "src/hooks/useAuth.test.ts", Framework: FrameworkJest, Line: 10, Name: "returns user when authenticated", Status: TestStatusActive},
+				{FilePath: "src/hooks/useAuth.test.ts", Framework: FrameworkJest, Line: 20, Name: "returns null when not authenticated", Status: TestStatusActive},
+				{FilePath: "src/hooks/useAuth.test.ts", Framework: FrameworkJest, Line: 30, Name: "handles login flow", Status: TestStatusTodo},
+			},
+		},
+		{
+			FilePath:  "src/utils/format.test.ts",
+			Framework: FrameworkVitest,
+			Tests: []TestCase{
+				{FilePath: "src/utils/format.test.ts", Framework: FrameworkVitest, Line: 5, Name: "formats date correctly", Status: TestStatusActive},
+				{FilePath: "src/utils/format.test.ts", Framework: FrameworkVitest, Line: 15, Name: "formats currency correctly", Status: TestStatusActive},
+				{FilePath: "src/utils/format.test.ts", Framework: FrameworkVitest, Line: 25, Name: "handles edge cases", Status: TestStatusSkipped},
+			},
+		},
+		{
+			FilePath:  "e2e/login.spec.ts",
+			Framework: FrameworkPlaywright,
+			Tests: []TestCase{
+				{FilePath: "e2e/login.spec.ts", Framework: FrameworkPlaywright, Line: 8, Name: "user can log in with valid credentials", Status: TestStatusActive},
+				{FilePath: "e2e/login.spec.ts", Framework: FrameworkPlaywright, Line: 20, Name: "shows error for invalid credentials", Status: TestStatusActive},
+				{FilePath: "e2e/login.spec.ts", Framework: FrameworkPlaywright, Line: 35, Name: "redirects to dashboard after login", Status: TestStatusActive},
+			},
+		},
+		{
+			FilePath:  "e2e/checkout.spec.ts",
+			Framework: FrameworkPlaywright,
+			Tests: []TestCase{
+				{FilePath: "e2e/checkout.spec.ts", Framework: FrameworkPlaywright, Line: 10, Name: "completes purchase flow", Status: TestStatusActive},
+				{FilePath: "e2e/checkout.spec.ts", Framework: FrameworkPlaywright, Line: 25, Name: "validates payment information", Status: TestStatusSkipped},
+				{FilePath: "e2e/checkout.spec.ts", Framework: FrameworkPlaywright, Line: 40, Name: "handles out of stock items", Status: TestStatusTodo},
+			},
+		},
+	}
+
+	summary := calculateSummary(suites)
+
+	return AnalysisResult{
+		AnalyzedAt: time.Now().UTC().Format(time.RFC3339),
+		CommitSHA:  mockCommitSHA,
+		Owner:      owner,
+		Repo:       repo,
+		Suites:     suites,
+		Summary:    summary,
+	}
+}

--- a/src/backend/analyzer/types.go
+++ b/src/backend/analyzer/types.go
@@ -1,0 +1,57 @@
+package analyzer
+
+type TestStatus string
+
+const (
+	TestStatusActive  TestStatus = "active"
+	TestStatusSkipped TestStatus = "skipped"
+	TestStatusTodo    TestStatus = "todo"
+)
+
+type Framework string
+
+const (
+	FrameworkJest       Framework = "jest"
+	FrameworkVitest     Framework = "vitest"
+	FrameworkPlaywright Framework = "playwright"
+	FrameworkGo         Framework = "go"
+)
+
+type TestCase struct {
+	FilePath  string     `json:"filePath"`
+	Framework Framework  `json:"framework"`
+	Line      int        `json:"line"`
+	Name      string     `json:"name"`
+	Status    TestStatus `json:"status"`
+}
+
+type TestSuite struct {
+	FilePath  string     `json:"filePath"`
+	Framework Framework  `json:"framework"`
+	Tests     []TestCase `json:"tests"`
+}
+
+type FrameworkSummary struct {
+	Active    int       `json:"active"`
+	Framework Framework `json:"framework"`
+	Skipped   int       `json:"skipped"`
+	Todo      int       `json:"todo"`
+	Total     int       `json:"total"`
+}
+
+type Summary struct {
+	Active     int                `json:"active"`
+	Frameworks []FrameworkSummary `json:"frameworks"`
+	Skipped    int                `json:"skipped"`
+	Todo       int                `json:"todo"`
+	Total      int                `json:"total"`
+}
+
+type AnalysisResult struct {
+	AnalyzedAt string      `json:"analyzedAt"`
+	CommitSHA  string      `json:"commitSha"`
+	Owner      string      `json:"owner"`
+	Repo       string      `json:"repo"`
+	Suites     []TestSuite `json:"suites"`
+	Summary    Summary     `json:"summary"`
+}

--- a/src/backend/cmd/server/main.go
+++ b/src/backend/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/specvital/web/src/backend/analyzer"
 	"github.com/specvital/web/src/backend/common/middleware"
 	"github.com/specvital/web/src/backend/health"
 )
@@ -51,6 +52,7 @@ func newRouter(origins []string) *chi.Mux {
 	r.Use(chimiddleware.Recoverer)
 	r.Use(middleware.CORS(origins))
 
+	analyzer.RegisterRoutes(r)
 	health.RegisterRoutes(r)
 
 	return r

--- a/src/backend/common/dto/problem.go
+++ b/src/backend/common/dto/problem.go
@@ -1,0 +1,38 @@
+package dto
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+const (
+	ContentTypeHeader     = "Content-Type"
+	JSONContentType       = "application/json"
+	ProblemJSONType       = "application/problem+json"
+	ProblemTypeAboutBlank = "about:blank"
+)
+
+// ProblemDetail represents RFC 7807 error response format.
+type ProblemDetail struct {
+	Detail   string `json:"detail"`
+	Instance string `json:"instance"`
+	Status   int    `json:"status"`
+	Title    string `json:"title"`
+	Type     string `json:"type"`
+}
+
+func SendProblemDetail(w http.ResponseWriter, r *http.Request, status int, title, detail string) {
+	problem := ProblemDetail{
+		Detail:   detail,
+		Instance: r.URL.Path,
+		Status:   status,
+		Title:    title,
+		Type:     ProblemTypeAboutBlank,
+	}
+	w.Header().Set(ContentTypeHeader, ProblemJSONType)
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(problem); err != nil {
+		slog.Error("failed to encode problem detail", "error", err)
+	}
+}


### PR DESCRIPTION
Add mock data API for frontend development
- GET /api/analyze/:owner/:repo endpoint
- Includes Jest, Vitest, Playwright framework examples
- Define AnalysisResult, TestSuite, TestCase types

fix #7