### PR TITLE
feat: implement test dashboard UI with mock API integration

### DIFF
--- a/src/frontend/components/framework-badge.tsx
+++ b/src/frontend/components/framework-badge.tsx
@@ -1,0 +1,32 @@
+import type { Framework } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type FrameworkBadgeProps = {
+  framework: Framework;
+};
+
+const FRAMEWORK_STYLES: Record<Framework, string> = {
+  go: "bg-cyan-100 text-cyan-800",
+  jest: "bg-red-100 text-red-800",
+  playwright: "bg-purple-100 text-purple-800",
+  vitest: "bg-green-100 text-green-800",
+};
+
+const capitalizeFramework = (framework: Framework): string => {
+  return framework.charAt(0).toUpperCase() + framework.slice(1);
+};
+
+export const FrameworkBadge = ({ framework }: FrameworkBadgeProps) => {
+  const colorClasses = FRAMEWORK_STYLES[framework];
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        colorClasses
+      )}
+    >
+      {capitalizeFramework(framework)}
+    </span>
+  );
+};

--- a/src/frontend/components/stats-card.tsx
+++ b/src/frontend/components/stats-card.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+
+type StatsCardProps = {
+  active: number;
+  label: string;
+  skipped: number;
+  todo: number;
+  total: number;
+};
+
+export const StatsCard = ({ active, label, skipped, todo, total }: StatsCardProps) => {
+  return (
+    <div className={cn("rounded-lg border bg-card p-6 shadow-xs")}>
+      <h3 className="text-lg font-semibold mb-4">{label}</h3>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <div className="flex flex-col">
+          <span className="text-3xl font-bold text-foreground">{total}</span>
+          <span className="text-sm text-muted-foreground">Total</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-3xl font-bold text-green-600">{active}</span>
+          <span className="text-sm text-muted-foreground">Active</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-3xl font-bold text-amber-600">{skipped}</span>
+          <span className="text-sm text-muted-foreground">Skipped</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-3xl font-bold text-blue-600">{todo}</span>
+          <span className="text-sm text-muted-foreground">Todo</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/components/test-item.tsx
+++ b/src/frontend/components/test-item.tsx
@@ -1,0 +1,48 @@
+import { Check, Circle, CircleDashed } from "lucide-react";
+import type { TestCase } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type TestItemProps = {
+  test: TestCase;
+};
+
+const STATUS_CONFIG = {
+  active: {
+    icon: Check,
+    color: "text-green-600",
+    label: "Active test",
+  },
+  skipped: {
+    icon: CircleDashed,
+    color: "text-amber-500",
+    label: "Skipped test",
+  },
+  todo: {
+    icon: Circle,
+    color: "text-blue-500",
+    label: "Todo test",
+  },
+} as const;
+
+export const TestItem = ({ test }: TestItemProps) => {
+  const config = STATUS_CONFIG[test.status];
+  const Icon = config.icon;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 px-3 py-2 rounded-md",
+        "hover:bg-muted/50 transition-colors"
+      )}
+    >
+      <Icon
+        className={cn("h-4 w-4 flex-shrink-0", config.color)}
+        aria-label={config.label}
+      />
+      <span className="flex-1 text-sm truncate">{test.name}</span>
+      <span className="text-xs text-muted-foreground font-mono flex-shrink-0">
+        L:{test.line}
+      </span>
+    </div>
+  );
+};

--- a/src/frontend/components/test-list.tsx
+++ b/src/frontend/components/test-list.tsx
@@ -1,0 +1,24 @@
+import type { TestSuite } from "@/lib/api";
+import { TestSuiteAccordion } from "./test-suite-accordion";
+
+type TestListProps = {
+  suites: TestSuite[];
+};
+
+export const TestList = ({ suites }: TestListProps) => {
+  if (suites.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-6 text-center text-muted-foreground">
+        No test suites found in this repository.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {suites.map((suite) => (
+        <TestSuiteAccordion key={`${suite.filePath}-${suite.framework}`} suite={suite} />
+      ))}
+    </div>
+  );
+};

--- a/src/frontend/components/test-suite-accordion.tsx
+++ b/src/frontend/components/test-suite-accordion.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { ChevronDown, ChevronRight, FileText } from "lucide-react";
+import { useState } from "react";
+import type { TestSuite } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { FrameworkBadge } from "./framework-badge";
+import { TestItem } from "./test-item";
+
+type TestSuiteAccordionProps = {
+  suite: TestSuite;
+};
+
+export const TestSuiteAccordion = ({ suite }: TestSuiteAccordionProps) => {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const toggleExpanded = () => {
+    setIsExpanded((prev) => !prev);
+  };
+
+  const testCount = suite.tests.length;
+
+  return (
+    <div className="rounded-lg border bg-card shadow-sm">
+      <button
+        className={cn(
+          "flex w-full items-center gap-3 px-4 py-3",
+          "hover:bg-muted/50 transition-colors",
+          "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+        )}
+        onClick={toggleExpanded}
+        aria-expanded={isExpanded}
+        aria-label={
+          isExpanded
+            ? `Collapse ${suite.filePath} test suite`
+            : `Expand ${suite.filePath} test suite`
+        }
+      >
+        {isExpanded ? (
+          <ChevronDown className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+        )}
+        <FileText className="h-5 w-5 flex-shrink-0 text-muted-foreground" />
+        <span className="flex-1 text-left text-sm font-medium truncate">
+          {suite.filePath}
+        </span>
+        <FrameworkBadge framework={suite.framework} />
+        <span className="text-xs text-muted-foreground flex-shrink-0">
+          {testCount} {testCount === 1 ? "test" : "tests"}
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div className="border-t bg-muted/20 px-4 py-2">
+          <div className="space-y-1 pl-6">
+            {suite.tests.length === 0 ? (
+              <div className="py-2 text-sm text-muted-foreground">No tests in this suite.</div>
+            ) : (
+              suite.tests.map((test) => (
+                <TestItem key={`${test.line}-${test.name}`} test={test} />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/frontend/lib/api/client.ts
+++ b/src/frontend/lib/api/client.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+import type { AnalysisResult } from "./types";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+// Zod schema for runtime validation matching Go backend types
+const testStatusSchema = z.enum(["active", "skipped", "todo"]);
+
+const frameworkSchema = z.enum(["jest", "vitest", "playwright", "go"]);
+
+const testCaseSchema = z.object({
+  filePath: z.string(),
+  framework: frameworkSchema,
+  line: z.number(),
+  name: z.string(),
+  status: testStatusSchema,
+});
+
+const testSuiteSchema = z.object({
+  filePath: z.string(),
+  framework: frameworkSchema,
+  tests: z.array(testCaseSchema),
+});
+
+const frameworkSummarySchema = z.object({
+  active: z.number(),
+  framework: frameworkSchema,
+  skipped: z.number(),
+  todo: z.number(),
+  total: z.number(),
+});
+
+const summarySchema = z.object({
+  active: z.number(),
+  frameworks: z.array(frameworkSummarySchema),
+  skipped: z.number(),
+  todo: z.number(),
+  total: z.number(),
+});
+
+const analysisResultSchema = z.object({
+  analyzedAt: z.string(),
+  commitSha: z.string(),
+  owner: z.string(),
+  repo: z.string(),
+  suites: z.array(testSuiteSchema),
+  summary: summarySchema,
+});
+
+class ApiError extends Error {
+  constructor(
+    message: string,
+    public status?: number,
+    public responseBody?: unknown,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export const fetchAnalysis = async (
+  owner: string,
+  repo: string,
+): Promise<AnalysisResult> => {
+  const url = `${API_URL}/api/analyze/${owner}/${repo}`;
+
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+  } catch (error) {
+    throw new ApiError(
+      `Failed to fetch analysis: ${error instanceof Error ? error.message : "Network error"}`,
+    );
+  }
+
+  if (!response.ok) {
+    let responseBody: unknown;
+
+    try {
+      responseBody = await response.json();
+    } catch {
+      responseBody = await response.text();
+    }
+
+    throw new ApiError(
+      `API request failed: ${response.statusText}`,
+      response.status,
+      responseBody,
+    );
+  }
+
+  let data: unknown;
+
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new ApiError(
+      `Failed to parse response as JSON: ${error instanceof Error ? error.message : "Parse error"}`,
+    );
+  }
+
+  const parseResult = analysisResultSchema.safeParse(data);
+
+  if (!parseResult.success) {
+    throw new ApiError(
+      `Invalid response format: ${parseResult.error.message}`,
+      undefined,
+      data,
+    );
+  }
+
+  return parseResult.data;
+};

--- a/src/frontend/lib/api/index.ts
+++ b/src/frontend/lib/api/index.ts
@@ -1,0 +1,10 @@
+export { fetchAnalysis } from "./client";
+export type {
+  AnalysisResult,
+  Framework,
+  FrameworkSummary,
+  Summary,
+  TestCase,
+  TestStatus,
+  TestSuite,
+} from "./types";

--- a/src/frontend/lib/api/types.ts
+++ b/src/frontend/lib/api/types.ts
@@ -1,0 +1,44 @@
+// Synced with backend: src/backend/analyzer/types.go
+
+export type TestStatus = "active" | "skipped" | "todo";
+
+export type Framework = "jest" | "vitest" | "playwright" | "go";
+
+export type TestCase = {
+  filePath: string;
+  framework: Framework;
+  line: number;
+  name: string;
+  status: TestStatus;
+};
+
+export type TestSuite = {
+  filePath: string;
+  framework: Framework;
+  tests: TestCase[];
+};
+
+export type FrameworkSummary = {
+  active: number;
+  framework: Framework;
+  skipped: number;
+  todo: number;
+  total: number;
+};
+
+export type Summary = {
+  active: number;
+  frameworks: FrameworkSummary[];
+  skipped: number;
+  todo: number;
+  total: number;
+};
+
+export type AnalysisResult = {
+  analyzedAt: string;
+  commitSha: string;
+  owner: string;
+  repo: string;
+  suites: TestSuite[];
+  summary: Summary;
+};

--- a/src/frontend/lib/utils.ts
+++ b/src/frontend/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge";
 export const cn = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs));
 };
+
+export const formatAnalysisDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  return date.toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+};
+
+export const SHORT_SHA_LENGTH = 7;

--- a/src/frontend/next-env.d.ts
+++ b/src/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Implemented test analysis dashboard UI integrated with mock API.

Changes:
- Add API client layer with Zod runtime validation
- StatsCard: display test statistics (Total/Active/Skipped/Todo)
- FrameworkBadge: color-coded framework badges
- TestList/TestSuiteAccordion: collapsible test suite list
- TestItem: individual test case display
- Add empty state handling and extract utility functions

fix #9